### PR TITLE
[fix] 메인 페이지 버튼 소개 카드와 동일하게 움직이도록 수정

### DIFF
--- a/my-app/src/component/main/IntroduceCard.js
+++ b/my-app/src/component/main/IntroduceCard.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { useState } from "react";
 import styled from "styled-components";
-import Ishihara1 from "./img/Ishihara_1.png";
-import Ishihara2 from "./img/Ishihara_2.png";
+import Ishihara1 from "../img/Ishihara_1.png";
+import Ishihara2 from "../img/Ishihara_2.png";
 
 const StyleIntroduceCard = styled.main`
   width: 480px;
@@ -13,8 +13,8 @@ const StyleIntroduceCard = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: auto;
-  margin-top: 30px;
+  /* margin: auto; */
+  margin: 30px;
 `;
 
 const StyleIntroduceTitle = styled.p`

--- a/my-app/src/page/MainPage.js
+++ b/my-app/src/page/MainPage.js
@@ -1,8 +1,15 @@
 import Header from "../component/header/Header";
-import IntroduceCard from "../component/IntroduceCard";
+import IntroduceCard from "../component/main/IntroduceCard";
 import FormBtn from "../component/commons/FormBtn";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
+
+const StyleMain = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
 
 const StyleBtnContainer = styled.div`
   display: flex;
@@ -19,10 +26,10 @@ const MainPage = () => {
   return (
     <>
       <Header />
-      <IntroduceCard />
-      <StyleBtnContainer onClick={gotochange}>
-        <FormBtn value="IMAGE" />
-      </StyleBtnContainer>
+      <StyleMain>
+        <IntroduceCard />
+        <FormBtn onClick={gotochange} value="IMAGE" />
+      </StyleMain>
     </>
   );
 };


### PR DESCRIPTION
##구현기능
- 메인 페이지에서 브라우저의 창이 줄어들 때 소개 카드와 이미지 업로드 페이지로 이동하는 버튼이 따로 움직이는 점 수정하였습니다. 